### PR TITLE
fix: Ensure default value for reward distribution in exam form

### DIFF
--- a/src/pages/app/exams/edit/[examId].tsx
+++ b/src/pages/app/exams/edit/[examId].tsx
@@ -54,7 +54,7 @@ function ExamForm({ exam }: ExamFormProps) {
           title: exam.title,
           description: exam.description,
           duration: exam.duration ? exam.duration.toString() : undefined,
-          rewardDistribution: exam.isRewarded,
+          rewardDistribution: exam.isRewarded ?? false,
           questions: exam.questions.map((q) => ({
             answers: q.options.map((o) => ({ answer: o.text })),
             correctAnswer: q.correctAnswer >= 0 ? q.correctAnswer.toString() : undefined,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with reward distribution initialization by ensuring a default boolean value is set when no value is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->