### PR TITLE
hotfix: Enable raw HTML rendering in Markdown components

### DIFF
--- a/src/components/create-exam/live-exam-preview.tsx
+++ b/src/components/create-exam/live-exam-preview.tsx
@@ -9,6 +9,7 @@ import remarkGfm from "remark-gfm";
 import { Card, CardHeader, CardHeaderContent, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/react/24/outline";
+import rehypeRaw from "rehype-raw";
 
 /** Basit ProgressBar */
 function ProgressBar({ current, total }: { current: number; total: number }) {
@@ -114,7 +115,7 @@ export function LiveExamPreview({ onGoBack }: LiveExamPreviewProps) {
             <div className="bg-white rounded-2xl flex flex-col gap-4">
               {/* Soru Metni */}
               <div className="border border-greyscale-light-200 bg-base-white rounded-3xl p-4 min-h-[240px] max-h-[320px] overflow-y-auto text-base">
-                <ReactMarkdown className="prose w-full" remarkPlugins={[remarkGfm]}>
+                <ReactMarkdown className="prose w-full" remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
                   {currentQuestion.question || ""}
                 </ReactMarkdown>
               </div>

--- a/src/components/create-exam/preview-modal.tsx
+++ b/src/components/create-exam/preview-modal.tsx
@@ -17,6 +17,7 @@ import {
 
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
 
 // 1) Farklı cihaz boyutlarını temsil eden bir enum ya da obje
 enum Device {
@@ -218,6 +219,7 @@ export function PreviewModal({
                   min-h-[120px]
                 "
                 remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
                 components={{
                   img: ({ node, ...props }) => (
                     <img {...props} className="max-w-full h-auto" loading="lazy" />


### PR DESCRIPTION
Add rehypeRaw plugin to ReactMarkdown in live exam preview and preview modal to support raw HTML rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Markdown display in exam previews and modal windows now supports embedded HTML, allowing for richer formatting of exam content.
  - This update delivers a more dynamic and visually engaging experience while maintaining consistency with existing content presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->