### PR TITLE
hotfix: Add rehypeRaw plugin to Markdown components 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "react-redux": "^8.1.3",
         "react-responsive-carousel": "^3.2.23",
         "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.0",
         "tailwind-merge": "^2.5.3",
         "tailwindcss-animate": "^1.0.7",
@@ -14145,6 +14146,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.0.tgz",
@@ -20135,6 +20151,20 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-redux": "^8.1.3",
     "react-responsive-carousel": "^3.2.23",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.0",
     "tailwind-merge": "^2.5.3",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/create-exam/live-exam-preview.tsx
+++ b/src/components/create-exam/live-exam-preview.tsx
@@ -9,6 +9,7 @@ import remarkGfm from "remark-gfm";
 import { Card, CardHeader, CardHeaderContent, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/react/24/outline";
+import rehypeRaw from "rehype-raw";
 /** Basit ProgressBar */
 function ProgressBar({ current, total }: { current: number; total: number }) {
   const progress = total > 0 ? (current / total) * 100 : 0;
@@ -128,6 +129,7 @@ export function LiveExamPreview({ onGoBack }: LiveExamPreviewProps) {
                     [&_img]:rounded-lg [&_img]:max-w-full [&_img]:my-4 [&_img]:mx-auto [&_img]:block
                     [&_hr]:my-6 [&_hr]:border-gray-200"
                   remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeRaw]}
                   components={{
                     a: ({ node, ...props }) => (
                       <a className="text-blue-600 hover:underline font-medium" {...props} />

--- a/src/components/create-exam/live-exam-preview.tsx
+++ b/src/components/create-exam/live-exam-preview.tsx
@@ -10,6 +10,7 @@ import { Card, CardHeader, CardHeaderContent, CardTitle, CardContent } from "@/c
 import { Button } from "@/components/ui/button";
 import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/react/24/outline";
 import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 /** Basit ProgressBar */
 function ProgressBar({ current, total }: { current: number; total: number }) {
   const progress = total > 0 ? (current / total) * 100 : 0;
@@ -129,7 +130,7 @@ export function LiveExamPreview({ onGoBack }: LiveExamPreviewProps) {
                     [&_img]:rounded-lg [&_img]:max-w-full [&_img]:my-4 [&_img]:mx-auto [&_img]:block
                     [&_hr]:my-6 [&_hr]:border-gray-200"
                   remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeRaw]}
+                  rehypePlugins={[rehypeRaw, rehypeSanitize]}
                   components={{
                     a: ({ node, ...props }) => (
                       <a className="text-blue-600 hover:underline font-medium" {...props} />

--- a/src/components/create-exam/preview-modal.tsx
+++ b/src/components/create-exam/preview-modal.tsx
@@ -18,6 +18,7 @@ import {
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 
 // 1) Farklı cihaz boyutlarını temsil eden bir enum ya da obje
 enum Device {
@@ -219,7 +220,7 @@ export function PreviewModal({
                   min-h-[120px]
                 "
                 remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeRaw]}
+                rehypePlugins={[rehypeRaw, rehypeSanitize]}
                 components={{
                   img: ({ node, ...props }) => (
                     <img {...props} className="max-w-full h-auto" loading="lazy" />

--- a/src/components/exam/exam-preview-modal.tsx
+++ b/src/components/exam/exam-preview-modal.tsx
@@ -7,6 +7,7 @@ import remarkGfm from "remark-gfm";
 import { Button } from "@/components/ui/button"; // Sizin buton bileşeniniz
 import { XMarkIcon } from "@heroicons/react/24/outline"; // Kapatma ikonu (opsiyonel)
 import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 
 interface ExamPreviewModalProps {
   content: string;
@@ -58,13 +59,12 @@ export function ExamPreviewModal({ content, onClose }: ExamPreviewModalProps) {
           {/* Quiz Description (Markdown) */}
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeRaw]}
+            rehypePlugins={[rehypeRaw, rehypeSanitize]}
             components={{
               img: ({ node, ...props }) => (
                 <img {...props} className="max-w-full h-auto" loading="lazy" />
               ),
             }}
-
           >
             {content || "No content"}
           </ReactMarkdown>

--- a/src/components/exam/exam-preview-modal.tsx
+++ b/src/components/exam/exam-preview-modal.tsx
@@ -6,6 +6,7 @@ import remarkGfm from "remark-gfm";
 
 import { Button } from "@/components/ui/button"; // Sizin buton bileşeniniz
 import { XMarkIcon } from "@heroicons/react/24/outline"; // Kapatma ikonu (opsiyonel)
+import rehypeRaw from "rehype-raw";
 
 interface ExamPreviewModalProps {
   content: string;
@@ -57,11 +58,13 @@ export function ExamPreviewModal({ content, onClose }: ExamPreviewModalProps) {
           {/* Quiz Description (Markdown) */}
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeRaw]}
             components={{
               img: ({ node, ...props }) => (
                 <img {...props} className="max-w-full h-auto" loading="lazy" />
               ),
             }}
+
           >
             {content || "No content"}
           </ReactMarkdown>

--- a/src/pages/app/exams/[slug].tsx
+++ b/src/pages/app/exams/[slug].tsx
@@ -39,6 +39,7 @@ import { ExamNavigation } from "@/components/live-exam/exam-navigation";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 
 // Dialog (Modal) Components
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -266,7 +267,7 @@ function LiveQuiz() {
                 <ReactMarkdown
                   className="prose max-w-none w-full p-2 md:p-4 break-words"
                   remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeRaw]} 
+                  rehypePlugins={[rehypeRaw, rehypeSanitize]}
                   components={{
                     img: ({ node, ...props }) => (
                       <img {...props} className="max-w-full h-auto" loading="lazy" />

--- a/src/pages/app/exams/details/[examId].tsx
+++ b/src/pages/app/exams/details/[examId].tsx
@@ -7,6 +7,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import AttendanceCharts from "@/components/details/attendanceCharts";
 import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 
 function walletRender(walletAddress: string): string {
   return `${walletAddress.slice(0, 5)}...${walletAddress.slice(-5)}`;
@@ -130,7 +131,7 @@ const ExamDetails = () => {
               <ReactMarkdown
                 className="prose max-w-full text-sm sm:text-base"
                 remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeRaw]}
+                rehypePlugins={[rehypeRaw, rehypeSanitize]}
               >
                 {data.description || "No description available"}
               </ReactMarkdown>

--- a/src/pages/app/exams/details/[examId].tsx
+++ b/src/pages/app/exams/details/[examId].tsx
@@ -6,6 +6,7 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import AttendanceCharts from "@/components/details/attendanceCharts";
+import rehypeRaw from "rehype-raw";
 
 function walletRender(walletAddress: string): string {
   return `${walletAddress.slice(0, 5)}...${walletAddress.slice(-5)}`;
@@ -129,6 +130,7 @@ const ExamDetails = () => {
               <ReactMarkdown
                 className="prose max-w-full text-sm sm:text-base"
                 remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
               >
                 {data.description || "No description available"}
               </ReactMarkdown>

--- a/src/pages/app/exams/get-started/[slug].tsx
+++ b/src/pages/app/exams/get-started/[slug].tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 
 function ExamDetail() {
   const router = useRouter();
@@ -228,7 +229,7 @@ function ExamDetail() {
                 <ReactMarkdown
                   className="mdxeditor"
                   remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeRaw]}
+                  rehypePlugins={[rehypeRaw, rehypeSanitize]}
                   components={{
                     img: ({ node, ...props }) => (
                       <img {...props} className="max-w-full h-auto" loading="lazy" />


### PR DESCRIPTION
for raw HTML rendering

- Enable raw HTML rendering in LiveExamPreview, ExamPreviewModal, and ExamDetails components
- Import and configure rehypeRaw plugin for ReactMarkdown
- Improve markdown rendering flexibility across multiple components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced exam content display by enabling richer markdown rendering. Exam previews and details now support embedded HTML, providing more flexible and engaging presentations of exam information.
  - Added a confirmation modal for users when finishing a quiz, improving user interaction and error handling.

- **Bug Fixes**
  - Implemented sanitization for raw HTML content to enhance security across various components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->